### PR TITLE
Wallpaper changer for macOS

### DIFF
--- a/Wallpaper_Changer_macOS/README.md
+++ b/Wallpaper_Changer_macOS/README.md
@@ -1,0 +1,11 @@
+# macOS Wallpaper Changer
+
+This script launches Spotlight to launch Terminal.app in order to download a picture, and sets it as a wallpaper, in less than 3 seconds.
+
+Feel free to change the image link in the script in order to set another image.
+
+Changing the download path (/Users/Shared/wallpaper.jpg) may crash the AppleScript executed to change the wallpaper.
+
+## How to change macOS Wallpaper with the Terminal
+
+https://apple.stackexchange.com/questions/40644/how-do-i-change-desktop-background-with-a-terminal-command

--- a/Wallpaper_Changer_macOS/Wallpaper_Changer_macOS
+++ b/Wallpaper_Changer_macOS/Wallpaper_Changer_macOS
@@ -1,0 +1,28 @@
+// This script launches Spotlight to launch Terminal.app in order to download a picture, and sets it as a wallpaper, in less than 3 seconds.
+// Tested on El Capitan (macOS 10.11.6)
+#include "DigiKeyboard.h"
+void setup() {
+}
+
+void loop() {
+  DigiKeyboard.sendKeyStroke(0);
+  DigiKeyboard.delay(200);
+  DigiKeyboard.sendKeyStroke(KEY_SPACE, MOD_GUI_LEFT);
+  DigiKeyboard.delay(200);
+  DigiKeyboard.print("Terminal");
+  DigiKeyboard.delay(200);
+  DigiKeyboard.sendKeyStroke(KEY_ENTER);
+  DigiKeyboard.delay(200);
+  DigiKeyboard.print("curl https://tr3.cbsistatic.com/hub/i/2014/05/15/f8964afd-bd82-4e0e-bcbe-e927363dcdc1/3b858e39e2cf183b878f54cad0073a67/codedoge.jpg > /Users/Shared/wallpaper.jpg");
+  DigiKeyboard.delay(500);
+  DigiKeyboard.sendKeyStroke(KEY_ENTER);
+  DigiKeyboard.print("osascript -e 'tell application \"Finder\" to set desktop picture to POSIX file \"/Users/Shared/wallpaper.jpg\"'");
+  DigiKeyboard.delay(200);
+  DigiKeyboard.sendKeyStroke(KEY_ENTER);
+  DigiKeyboard.delay(200);
+  DigiKeyboard.sendKeyStroke(KEY_Q, MOD_GUI_LEFT);
+
+  for (;;) {
+    /*Stops the digispark from running the scipt again*/
+  }
+}


### PR DESCRIPTION
This script allows to change the wallpaper on macOS in less than 3 seconds, and it doesn't require to reboot the computer to make the changes effective.

Tested on an iMac with El Capitan (10.11) with a US Apple Keyboard layout.